### PR TITLE
Fix God of Thunder exhaust cost

### DIFF
--- a/Sets/SetScripts_thor.json
+++ b/Sets/SetScripts_thor.json
@@ -351,6 +351,11 @@
 					]
 				},
 				{
+					"name": "exhaust_card",
+					"subject": "self",
+					"is_cost": true
+				},
+				{
 					"name": "add_resource",
 					"amount": 1,
 					"resource_name": "energy"


### PR DESCRIPTION
Exhaust God of Thunder when its resource ability is used.
Keep the existing hero resource constraint and energy gain.